### PR TITLE
feat: add validator wandb log

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,7 @@ APIFY_API_KEY='apify_api_xxxxxx'
 
 ######### Validator ########
 OPENAI_API_KEY="sk-xxxxxx"
+WANDB_API_KEY="xxxxxx"
 
 ########## Miner ##########
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ lib64
 pyvenv.cfg
 share/
 
+# wandb logs
+wandb/
+
 # pm2 config file
 app.config.js
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -20,6 +20,7 @@ import json
 import os
 import random
 import time
+import wandb
 from datetime import datetime, timezone
 from traceback import print_exception
 
@@ -30,6 +31,7 @@ import torch
 from dotenv import load_dotenv
 
 import openkaito
+from openkaito import __version__
 from openkaito.base.validator import BaseValidatorNeuron
 from openkaito.crawlers.twitter.apidojo import ApiDojoTwitterCrawler
 from openkaito.crawlers.twitter.microworlds import MicroworldsTwitterCrawler
@@ -66,6 +68,25 @@ class Validator(BaseValidatorNeuron):
         with open("twitter_usernames.txt") as f:
             twitter_usernames = f.read().strip().splitlines()
         self.twitter_usernames = twitter_usernames
+
+        if os.getenv("WANDB_API_KEY") is None:
+            bt.logging.warning(
+                "!!! WANDB_API_KEY not found in environment variables. You are strongly recommended to set it. We may enforce to make it required in the future."
+            )
+            self.config.neuron.wandb_off = True
+
+        if not self.config.neuron.wandb_off:
+            wandb.login(key=os.environ["WANDB_API_KEY"], verify=True, relogin=True)
+            wandb.init(
+                project=f"sn{self.config.netuid}-validators",
+                entity="subnet-openkaito",
+                config={
+                    "hotkey": self.wallet.hotkey.ss58_address,
+                },
+                name=f"validator-{self.uid}-{__version__}",
+                resume="auto",
+                dir=self.config.neuron.full_path,
+            )
 
     async def forward(self):
         """
@@ -136,6 +157,26 @@ class Validator(BaseValidatorNeuron):
             bt.logging.info(f"Scored responses: {rewards} for {miner_uids}")
 
             self.update_scores(rewards, miner_uids)
+
+            if not self.config.neuron.wandb_off:
+                wandb_log = {
+                    "synapse": search_query.json(),
+                    "scores": {
+                        uid.item(): reward.item()
+                        for uid, reward in zip(miner_uids, rewards)
+                    },
+                    "responses": {
+                        uid.item(): json.dumps(response)
+                        for uid, response in zip(miner_uids, responses)
+                    },
+                }
+                wandb.log(wandb_log)
+                bt.logging.debug("wandb_log", wandb_log)
+            else:
+                bt.logging.warning(
+                    "!!! WANDB is not enabled. You are strongly recommended to obtain and set WANDB_API_KEY. We may enforce to make it required in the future."
+                )
+
         except Exception as e:
             bt.logging.error(f"Error during forward: {e}")
             bt.logging.debug(print_exception(type(e), e, e.__traceback__))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -213,10 +213,11 @@ class Validator(BaseValidatorNeuron):
             bt.logging.success("Validator killed by keyboard interrupt.")
             exit()
 
-        # In case of unforeseen errors, the validator will log the error and continue operations.
+        # In case of unforeseen errors, the validator will log the error and exit. (restart by pm2)
         except Exception as err:
             bt.logging.error("Error during validation", str(err))
             bt.logging.debug(print_exception(type(err), err, err.__traceback__))
+            self.should_exit = True
 
     def print_info(self):
         metagraph = self.metagraph
@@ -240,4 +241,8 @@ if __name__ == "__main__":
     with Validator() as validator:
         while True:
             validator.print_info()
+            if validator.should_exit:
+                bt.logging.warning("Ending validator...")
+                break
+
             time.sleep(30)

--- a/openkaito/__init__.py
+++ b/openkaito/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/openkaito/base/validator.py
+++ b/openkaito/base/validator.py
@@ -265,7 +265,10 @@ class BaseValidatorNeuron(BaseNeuron):
         self.metagraph.sync(subtensor=self.subtensor)
 
         # Check if the metagraph axon info has changed.
-        if previous_metagraph.axons == self.metagraph.axons:
+        if (
+            previous_metagraph.axons == self.metagraph.axons
+            and self.hotkeys == self.metagraph.hotkeys
+        ):
             return
 
         bt.logging.info(

--- a/openkaito/utils/config.py
+++ b/openkaito/utils/config.py
@@ -99,6 +99,12 @@ def add_args(cls, parser):
         help="If set, we dont save events to a log file.",
         default=False,
     )
+    parser.add_argument(
+        "--neuron.wandb_off",
+        action="store_true",
+        help="If set, we dont use wandb.",
+        default=False,
+    )
 
     if neuron_type == "validator":
         parser.add_argument(

--- a/quickstart.md
+++ b/quickstart.md
@@ -260,6 +260,16 @@ OPENAI_API_KEY="sk-xxxxxx"
 
 > Don't forget to also obtain and set the `APIFY_API_KEY` as mentioned in the above **General** section.
 
+### Obtain WandB API Key
+
+Log in to [Weights & Biases](https://wandb.ai) and generate a key in your account settings.
+
+Set the key `WANDB_API_KEY` in the `.env` file.
+
+```
+WANDB_API_KEY="your_wandb_api_key"
+```
+
 ### Install Dependencies
 
 To enable validator auto update with github repo, you can install `pm2` and `jq`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ apify-client
 elasticsearch
 python-dotenv
 pydantic
+wandb

--- a/scripts/export_wandb_history.py
+++ b/scripts/export_wandb_history.py
@@ -1,0 +1,22 @@
+import wandb
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Export wandb run metrics")
+    parser.add_argument("--run_id", type=str, required=True)
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    api = wandb.Api()
+
+    # run is specified by <entity>/<project>/<run_id>
+    run = api.run(f"subnet-openkaito/sn5-validators/{args.run_id}")
+
+    metrics_dataframe = run.history()
+    # metrics_dataframe.to_csv("metrics.csv")
+    print(metrics_dataframe)


### PR DESCRIPTION
![image](https://github.com/OpenKaito/openkaito/assets/14780887/6485de5a-4098-40a4-b47e-3e073e25e9ff)

validators now can share their scores and responses for each request and miner on wandb. Wandb is optional for now but is strongly recommended for all validators to enable it 