### PR TITLE
Remove defunct twitter users and blacklist updates

### DIFF
--- a/openkaito/utils/config.py
+++ b/openkaito/utils/config.py
@@ -203,6 +203,13 @@ def add_args(cls, parser):
             default=False,
         )
 
+        parser.add_argument(
+            "--blacklist.validator_min_stake",
+            type=int,
+            help="If set, miners will blacklist requests from validators with stake less than this value.",
+            default=10000,
+        )
+
 
 def config(cls):
     """

--- a/openkaito/utils/config.py
+++ b/openkaito/utils/config.py
@@ -207,7 +207,7 @@ def add_args(cls, parser):
             "--blacklist.validator_min_stake",
             type=int,
             help="If set, miners will blacklist requests from validators with stake less than this value.",
-            default=10000,
+            default=1000,
         )
 
 

--- a/twitter_usernames.txt
+++ b/twitter_usernames.txt
@@ -36,7 +36,6 @@ xcurveth
 lsp8940
 TeamUnibot
 Anonymoux2311
-iloveponzi
 0xAdelina
 friendtechindex
 The_Bogfather
@@ -104,7 +103,6 @@ krybharat
 mouisaac
 seedphrase
 CozomoMedici
-0xGav
 Evan_ss6
 cryptocevo
 natealexnft
@@ -261,7 +259,6 @@ scottmelker
 midasdn
 maverick23NFT
 ysiu
-scott_det
 krypto_kuz
 zxocw
 xiaozhouchonga
@@ -367,11 +364,9 @@ raiinnft
 jeth_sutil
 jerallaire
 gmoneyNFT
-drboblax
 Teeird
 brennasparksxxx
 ABdeVilliers17
-jonitzler
 angel65535
 alpha_pls
 shekarnani42
@@ -389,7 +384,6 @@ slslslgogo1234
 SizeChad
 franklinisbored
 CroissantEth
-achiwoya
 Nate_Rivers
 Etherean007
 k2_nft
@@ -447,7 +441,6 @@ jimtalbot
 cole0x
 exit_friends
 roxana_sucara
-buyerofblood
 rizzodoc
 ApeDurden
 eliz883
@@ -457,7 +450,6 @@ rorrwzika
 BenArmstrongsX
 itsALLhalvening
 anildelphi
-aogigbah
 Fiskantes
 koreanjewcrypto
 bacontatum00
@@ -572,7 +564,6 @@ milady
 phantom_scribbs
 Wuhuoqiu
 CryptoVonDoom
-hajsndjd
 0xdasha
 Blue9mingu
 ThinkingBitmex
@@ -646,8 +637,6 @@ Mangorango22
 bendoverxbt
 FleuryNFT
 SplitCapital
-Sencrazy_
-BigHead_crypt0
 Fiona_longhair
 TheSpiderSenses
 art_xbt
@@ -717,7 +706,6 @@ FancyXBT
 blackbird_xyz
 upblissed
 moon_guurl
-Huddy0x
 giciullini
 mdudas
 crypto_hunterW3
@@ -778,7 +766,6 @@ hype_eth
 brrnaby
 AlfaFrensFT
 BrkEvnCap
-andrejzahvato84
 Peterandjuly0
 fejau_inc
 buyingyourstops
@@ -806,7 +793,6 @@ brucelolzz
 WinMasterz
 inmortalcrypto
 BMTbbb
-friendtechdata
 astekz
 JiaHo
 intern
@@ -834,15 +820,12 @@ PaikCapital
 leap_xyz
 smolcap2
 Yiqiqifei6
-hongshen6666
 Therealtarzan7
 4_What4
 SexyMichill
 khal_hodl
-g3_capital
 BrainBroCrypto
 KaptajnAhab
-penglj118
 Dacovski_NFT
 FarmerBrownDeFi
 WYZRD_
@@ -925,7 +908,6 @@ gregisenberg
 promesx1
 cryptopilot16
 zestycheeto
-modestfrfr
 ESK_NFT
 0xWangarian
 Sicarious_
@@ -944,7 +926,6 @@ tervoooo
 mattmedved
 multichainchad
 Harryleemedia
-ug_pavel
 sen_eth
 honey_xbt
 _tolks
@@ -994,7 +975,6 @@ RougeVert4
 proto_jeff
 sitinurlia603
 0xzuberg
-brokenangle8891
 fintechfrank
 daomaker
 fozziewrites_
@@ -1014,7 +994,6 @@ FnordyNFT
 CryptoGorillaYT
 ercwl
 spreekaway
-galaxyRTK
 Nickp_xxx
 0xPajke
 coindae
@@ -1023,7 +1002,6 @@ kornik_crypto
 Nakameowdough
 OnlyToasted
 jacknuked
-FRIEND_TRACKER
 wallstreetbets
 hyuktrades
 0xBryannnn
@@ -1062,7 +1040,6 @@ functi0nZer0
 RexHuang7
 Fwiz
 coinfessions
-DreamShitposter
 0xCygaar
 satofishi
 Cooopahtroopa
@@ -1136,7 +1113,6 @@ calchulus
 Mystic_Ether
 therobotjames
 mishkabuns
-peachmint00
 DanyyNFT
 BalesBets
 mindsurf
@@ -1190,7 +1166,6 @@ kkwak39
 tillgrepp
 0xShual
 yagamiofnft
-flyingmountain0
 QDfund
 fusionistio
 BabyBeraFinance
@@ -1345,7 +1320,6 @@ henri_stern
 ljin18
 ccdhahby
 DefiIgnas
-Who_Me_Yo
 sleepy0x13
 Mulan0x
 RKSK94
@@ -1516,7 +1490,6 @@ Binothegoodman
 TheNFTAsian_JP
 tungweb3
 0ctoshi
-bittybags
 Mortpoker
 Soul6853
 hungnm10
@@ -1542,7 +1515,6 @@ ButtplugAdapter
 defipeasant
 D34thSt4lker
 DannyCrypt
-RJ_Killmex
 CryptoPoseidonn
 0xSolarcurve
 kdimes00
@@ -1635,7 +1607,6 @@ OnlyfrensIndex
 sbh_studio
 jasm_eth
 themafiaboss420
-DegenBazza
 Dear_Komick
 boatnudlez
 nindibabi
@@ -1673,7 +1644,6 @@ PixelRainbowNFT
 fridgeintheopen
 Nick_Prince12
 AGLuna12
-Rstreetbet5
 3eleth
 PabloPunkasso
 HighCoinviction
@@ -1710,7 +1680,6 @@ MaisonGhost
 SmartMoneyAlrt
 EthRydium
 Jun57903Jun
-AskFiller
 AlexanderGrieve
 sergitosergito
 caseykeke
@@ -1724,7 +1693,6 @@ chowfun69
 CrypSaf
 greektoshi
 keydrop_fun
-MrBigTimeCEO
 Muddawg
 GoingParabolic
 nansenooor


### PR DESCRIPTION
- Bail out from blacklist function early if `allow_non_registered` is true to prevent traceback (when doing `.index()` and subsequent uid lookups).
- Set minimum validator stake to allow requests - this was added to sn24 to prevent an exploit where a miner with small stake was allowed to query other miners due to vpermit, default to 10k.
- Removed default twitter usernames.