### PR TITLE
docs: fix typos

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # OpenKaito Validator API
 
-Validtor can setup an API server to issue search queries to the network, for building Apps on OpenKaito subnet, interacting with other subnets, etc. The API server will be responsible for issuing search queries to the network and receiving ranked results from miners.
+Validator can setup an API server to issue search queries to the network, for building Apps on OpenKaito subnet, interacting with other subnets, etc. The API server will be responsible for issuing search queries to the network and receiving ranked results from miners.
 
 To setup the API server, you need to config via the `.env` file,
 

--- a/docs/openkaito_v0_legacy.md
+++ b/docs/openkaito_v0_legacy.md
@@ -25,7 +25,7 @@ Please see [Miner Setup](https://github.com/MetaSearch-IO/decentralized-search/b
 
 ### The Problem
 The internet is becoming more closed than open -
-- **Paradigm Shift**: Data is increasingly generated and hosted on closed platforms rathen than the open web.
+- **Paradigm Shift**: Data is increasingly generated and hosted on closed platforms rather than the open web.
 - **Data Restrictions**: More platforms are imposing greater restrictions on public user data (eg X, Reddit).
 - **The Consequence**: A less open internet and greater centralization of power to platforms.
 
@@ -125,7 +125,7 @@ Rewards are based on the following criteria:
 
 ### Validator API Server
 
-Validtor can setup an API server to issue search queries to the network, for building Apps on OpenKaito subnet, interacting with other subnets, etc. The API server will be responsible for issuing search queries to the network and receiving ranked results from miners.
+Validator can setup an API server to issue search queries to the network, for building Apps on OpenKaito subnet, interacting with other subnets, etc. The API server will be responsible for issuing search queries to the network and receiving ranked results from miners.
 
 To setup the API server, you can set some api keys in `.env` file separated by comma,
 

--- a/docs/query_and_response_api.md
+++ b/docs/query_and_response_api.md
@@ -77,7 +77,7 @@ The miner’s response is a list of ranked documents.
 [
   {
     "id": "1769458523031892221",
-    "text": "You're witnessing the single largest transfer of wealth in human history\n\nThis will be written about in history books\n\nYour grandchildren will never question the validity of crypto\n\nBut you psych yourself out and sell to early every single time",
+    "text": "You're witnessing the single largest transfer of wealth in human history\n\nThis will be written about in history books\n\nYour grandchildren will never question the validity of crypto\n\nBut you psych yourself out and sell too early every single time",
     "created_at": "2024-03-17T20:19:21+00:00",
     "username": "ozarknft",
     "url": "https://x.com/ozarknft/status/1769458523031892221",

--- a/docs/running_on_staging.md
+++ b/docs/running_on_staging.md
@@ -146,7 +146,7 @@ btcli wallet new_hotkey --wallet.name validator --wallet.hotkey default
 
 ## 8. Mint tokens from faucet
 
-You will need tokens to initialize the intentive mechanism on the chain as well as for registering the subnet. 
+You will need tokens to initialize the incentive mechanism on the chain as well as for registering the subnet. 
 
 Run the following commands to mint faucet tokens for the owner and for the validator.
 
@@ -309,7 +309,7 @@ python neurons/validator.py --netuid 1 --subtensor.chain_endpoint ws://127.0.0.1
 
 ## 14. Set weights for your subnet
 
-Register a validator on the root subnet and boost to set weights for your subnet. This is a necessary step to ensure that the subnet is able to receive emmissions.
+Register a validator on the root subnet and boost to set weights for your subnet. This is a necessary step to ensure that the subnet is able to receive emissions.
 
 ### Register your validator on the root subnet
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -45,7 +45,7 @@ cp .env.example .env
 
 ### Setup Elasticsearch
 
-To be a miner of openkaito, you need to have an Elasticsearch instance running. You can install Elasticsearch by following the instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html). That includes intalling [docker](https://docs.docker.com/engine/install/) and run the Elasticsearch docker image.
+To be a miner of openkaito, you need to have an Elasticsearch instance running. You can install Elasticsearch by following the instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html). That includes installing [docker](https://docs.docker.com/engine/install/) and run the Elasticsearch docker image.
 
 #### Install Docker
 
@@ -251,7 +251,7 @@ To obtain better miner performance, you can consider the following options:
   - adjust the apify crawler running parameters, e.g., increase the size of on search crawling
   - implement a continuous crawler, instead of or in addition to the on search crawling, to crawl data and ingest into the Elasticsearch instance
 - build better ranking model
-  - customize the provied ranking model, e.g., tune the parameters for `length_weight` and `age_weight`
+  - customize the provided ranking model, e.g., tune the parameters for `length_weight` and `age_weight`
   - implement a better ranking model, e.g., integrating LLM
 - improve the recall stage
   - tune the parameters for the search query, e.g., adjust the `size` parameter via `MINER_SEARCH_RECALL_SIZE` in `.env`


### PR DESCRIPTION
# Rationale for this change

I checked all the ‘md’ files within the repository And found some typos that needed to be fixed because they clearly changed the meaning and fixed them. 

There were also some awkward wording and punctuation, but I didn't fix those because they don't detract too much from the meaning of the original documentation and don't cause any problems in understanding the documentation.

Fixing typos makes the documentation more readable and clear.
# Changes

Correct typos in the modified files. The commit explains which typos are corrected and reason.