### PR TITLE
feat: cap upper bound of score and improve the chunk logic v0.8.1++

### DIFF
--- a/openkaito/evaluation/evaluator.py
+++ b/openkaito/evaluation/evaluator.py
@@ -347,7 +347,7 @@ class Evaluator:
                 )
 
                 losses[i] = loss.item()
-                scores[i] = 1 / loss.item()
+                scores[i] = min(100.0, 1 / loss.item())
                 top1_recalls[i] = top1_recall.item()
                 top3_recalls[i] = top3_recall.item()
 

--- a/openkaito/tasks.py
+++ b/openkaito/tasks.py
@@ -309,10 +309,11 @@ def generate_relevant_pairs(
             continue
         sentences = sent_tokenize(text)
         num_sentences = len(sentences)
+        cur_num_pairs_per_article = num_pairs_per_article
         if num_sentences < min_sentences:
-            continue
+            cur_num_pairs_per_article = 1
         sizes = []
-        for _ in range(num_pairs_per_article):
+        for _ in range(cur_num_pairs_per_article):
             try:
                 # Determine the desired number of sentences in the chunk
                 chunk_size = max(1, int(random.gauss(num_sentences / 8, num_sentences / 4)))


### PR DESCRIPTION
- Add an upper bound of 100 to `scores[i]`. This change will not affect the top miners in the current version but is helpful for the minimal balance requirement.  
- Improve the logic for generating article chunks.